### PR TITLE
Unit conversion in TTG calculation

### DIFF
--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -165,7 +165,7 @@ function timeCalcs(
     : new Date()
 
   const dateMsec = date.getTime()
-  const ttgMsec = Math.floor((distance / (vmg * 0.514444)) * 1000)
+  const ttgMsec = Math.floor((distance / vmg) * 1000)
   const etaMsec = dateMsec + ttgMsec
 
   return {


### PR DESCRIPTION
I'm not sure if my problem is caused by misconfiguration of SignalK (a freshly installed 2.7.2 with few or no settings changes) of if it is indeed something that requires a change in this course provider plugin. I'm not an experienced SignalK user, apologies if I get this wrong.

I noticed when sailing that the TTG calculation was off. For example, we would have a distance to waypoint of 5 (nautical miles as displayed by my B&G instruments), speed/vmg of 5 (knots, as displayed) and the estimated time at waypoint was approx. 2 hours in the future, not one. The `navigation.course.calcValues.timeToGo` value calculated by this plugin, in seconds, was around 2 hours, but it should have been around 1 hour (5 nm at 5 kn). In other situations, the factor by which TTG was wrong was always around 2. In all cases we were headed directly towards the waypoint so VMG = SOG (approx).

So I tried to figure out the units that this plugin uses. `gcDistance` (https://github.com/SignalK/course-provider-plugin/blob/master/src/worker/course.ts#L73) should be in meters. `gcVmg` is in the unit of `navigation.speedOverGround`, which is m/s in my data browser (also specified in https://signalk.org/specification/1.5.0/doc/vesselsBranch.html#vesselsregexpnavigationspeedoverground - I don't think it can be changed?). So when calculating TTG in https://github.com/SignalK/course-provider-plugin/blob/master/src/worker/course.ts#L168, the calculation for TTG in seconds should be a simple `distance / vmg` for a result in seconds, but this plugin performs a unit conversion of `vmg` from knots to meters per seconds (multiplying by 0.514444). This calculation can only lead to correct results when `navigation.speedOverGround` is in knots, but that contradicts the SignalK spec, and the default settings in a fresh SignalK instance. 

Let me know what you think, I'm a bit surprised by my findings and not sure if others are experiencing the same issue. Thanks for developing a great tool for boaters!